### PR TITLE
Add basic dashboard skeleton

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,19 @@
+// Switch between workspace sections
+const sidebarLinks = document.querySelectorAll('#sidebar li');
+const sections = document.querySelectorAll('.workspace-section');
+
+sidebarLinks.forEach(link => {
+    link.addEventListener('click', () => {
+        const target = link.getAttribute('data-section');
+        sections.forEach(sec => {
+            sec.classList.toggle('hidden', sec.id !== target);
+        });
+    });
+});
+
+// Placeholder for websocket/fetch logic
+function initConnections() {
+    console.log('Initialize WebSocket or fetch');
+}
+
+document.addEventListener('DOMContentLoaded', initConnections);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard Test</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="app">
+        <aside id="sidebar">
+            <nav>
+                <ul>
+                    <li data-section="models">Models</li>
+                    <li data-section="versions">Versions</li>
+                    <li data-section="textures">Textures</li>
+                    <li data-section="parameters">Parameters</li>
+                    <li data-section="sync">Sync</li>
+                </ul>
+            </nav>
+        </aside>
+        <main id="workspace">
+            <header id="top-bar">
+                <input type="text" id="search" placeholder="Search" />
+                <button id="build-push">Build &amp; Push</button>
+                <span id="notifications">🔔</span>
+            </header>
+            <section id="models" class="workspace-section">Models area</section>
+            <section id="versions" class="workspace-section hidden">Versions area</section>
+            <section id="textures" class="workspace-section hidden">Textures area</section>
+            <section id="parameters" class="workspace-section hidden">Parameters area</section>
+            <section id="sync" class="workspace-section hidden">Sync area</section>
+        </main>
+    </div>
+
+    <script src="dashboard.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,50 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    display: flex;
+    height: 100vh;
+}
+
+#sidebar {
+    width: 200px;
+    background: #f0f0f0;
+    padding: 1rem;
+}
+
+#sidebar ul {
+    list-style: none;
+    padding: 0;
+}
+
+#sidebar li {
+    margin: 0.5rem 0;
+    cursor: pointer;
+}
+
+#workspace {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#top-bar {
+    display: flex;
+    align-items: center;
+    background: #e0e0e0;
+    padding: 0.5rem;
+}
+
+#top-bar input {
+    flex: 1;
+    margin-right: 0.5rem;
+}
+
+.workspace-section {
+    flex: 1;
+    padding: 1rem;
+    overflow-y: auto;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- add simple `index.html` containing sidebar and workspace
- add minimal layout in `styles.css`
- provide `dashboard.js` to switch between sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68496083c68c833290327b15975ea836