### PR TITLE
Add configurator sample and document endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # DashboardTest
+
+## Configurator endpoint
+
+Unity downloads the configurator data from the `/api/configurator/latest` endpoint. The service returns a JSON payload structured like `samples/configurator_example.json`.
+
+Example request:
+
+```http
+GET https://yourdomain.com/api/configurator/latest
+```
+
+This JSON describes available models, versions, textures and other parameters used by the Unity application.

--- a/samples/configurator_example.json
+++ b/samples/configurator_example.json
@@ -1,0 +1,24 @@
+{
+  "models": [
+    {
+      "name": "ExampleModel",
+      "versions": [
+        {
+          "version": "1.0",
+          "textures": [
+            "default.png"
+          ],
+          "parameters": {
+            "color": "red",
+            "size": "medium"
+          }
+        }
+      ]
+    }
+  ],
+  "bundleUrl": "https://example.com/bundles/examplemodel.bundle",
+  "metadata": {
+    "description": "Sample configuration for ExampleModel",
+    "author": "ACME Corp"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample configurator JSON
- document `/api/configurator/latest` endpoint in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849608511ec8332958c6c7dfa71a724